### PR TITLE
feat(pixo-platform/platform): add joinExtensions and completeExtensions to sessions

### DIFF
--- a/pixo-platform/Makefile
+++ b/pixo-platform/Makefile
@@ -35,4 +35,3 @@ report:
 	@echo "📊 Generating coverage report..."
 	@go test -cover -v -coverprofile=prof.out ./...
 	@go tool cover -html=prof.out
-

--- a/pixo-platform/allocator/builds.go
+++ b/pixo-platform/allocator/builds.go
@@ -58,6 +58,9 @@ func (a *Client) GetBuildWorkflowLogs(workflowName string) (chan *Log, error) {
 	path := fmt.Sprintf("build/workflows/%s/logs", workflowName)
 
 	req, err := a.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Set("Accept", "application/octet-stream")
 
 	res, err := a.Client().Do(req)

--- a/pixo-platform/platform/mock.go
+++ b/pixo-platform/platform/mock.go
@@ -3,10 +3,11 @@ package platform
 import (
 	"context"
 	"errors"
+	"time"
+
 	abstract "github.com/PixoVR/pixo-golang-clients/pixo-platform/abstract"
 	commonerrors "github.com/PixoVR/pixo-golang-server-utilities/pixo-platform/commonerrors"
 	"github.com/go-faker/faker/v4"
-	"time"
 )
 
 var _ Client = (*MockClient)(nil)
@@ -766,12 +767,12 @@ func (m *MockClient) CreateSession(ctx context.Context, session *Session) error 
 	m.Lock.Lock()
 	defer m.Lock.Unlock()
 
-	sessionCopy := *session
-	m.CalledCreateSessionWith = append(m.CalledCreateSessionWith, &sessionCopy)
-
 	if session == nil {
 		return errors.New("session can not be nil")
 	}
+
+	sessionCopy := *session
+	m.CalledCreateSessionWith = append(m.CalledCreateSessionWith, &sessionCopy)
 
 	if session.ModuleID <= 0 {
 		return errors.New("invalid module id")

--- a/pixo-platform/platform/sessions.go
+++ b/pixo-platform/platform/sessions.go
@@ -36,6 +36,9 @@ type Session struct {
 
 	CreatedAt time.Time `json:"createdAt,omitempty"`
 	UpdatedAt time.Time `json:"updatedAt,omitempty"`
+
+	JoinExtensions     *string `json:"joinExtensions,omitempty"`
+	CompleteExtensions *string `json:"completeExtensions,omitempty"`
 }
 
 type CreateSessionResponse struct {
@@ -115,6 +118,10 @@ func (p *clientImpl) CreateSession(ctx context.Context, session *Session) error 
 		variables["input"].(map[string]interface{})["specialization"] = session.Specialization
 	}
 
+	if session.JoinExtensions != nil {
+		variables["input"].(map[string]interface{})["joinExtensions"] = session.JoinExtensions
+	}
+
 	var res CreateSessionResponse
 	if err := p.Exec(ctx, query, &res, variables); err != nil {
 		return err
@@ -169,6 +176,10 @@ func (p *clientImpl) UpdateSession(ctx context.Context, session Session) (*Sessi
 
 	if session.ModuleVersion != "" {
 		variables["input"].(map[string]interface{})["moduleVersion"] = session.ModuleVersion
+	}
+
+	if session.CompleteExtensions != nil {
+		variables["input"].(map[string]interface{})["completeExtensions"] = session.CompleteExtensions
 	}
 
 	var res UpdateSessionResponse


### PR DESCRIPTION
- Added `joinExtensions` and `completeExtensions` fields to the `Session` struct.
- Updated `CreateSession` and `UpdateSession` methods to handle these new fields.